### PR TITLE
Allow user to choose cache directory

### DIFF
--- a/pylightcurve/__databases__.py
+++ b/pylightcurve/__databases__.py
@@ -28,7 +28,9 @@ class PlcData:
 
         self.build_in_databases_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), databases_file)
 
-        self.databases_directory_path = os.path.join(os.path.abspath(os.path.expanduser('~')),
+        base_path = os.environ.get('PYLC_CACHE_DIR',None) or os.path.expanduser('~')
+
+        self.databases_directory_path = os.path.join(os.path.abspath(base_path),
                                                      '.{0}'.format(self.package_name))
 
         self.databases_file_path = os.path.join(self.databases_directory_path, databases_file)


### PR DESCRIPTION
Included fix to allow the database to be stored somewhere else.
It can be done by exporting:
`export PYLC_CACHE_DIR=/path/to/cache`

If it is not set then it defaults back to the home folder

 The issue came about when running in Darwin as it does not allow you to write to the home folder when run as a job.
